### PR TITLE
Feature/ Support contracts with overloaded methods

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -20,4 +20,27 @@ macro_rules! use_contract {
 			struct _Dummy;
 		}
 	};
+
+	(@inner $module:ident, $path: expr, ($($signature:expr => $alias:expr),*)) => {
+        #[allow(dead_code)]
+		#[allow(missing_docs)]
+		#[allow(unused_imports)]
+		#[allow(unused_mut)]
+		#[allow(unused_variables)]
+		pub mod $module {
+			#[derive(ethabi_derive::EthabiContract)]
+			#[ethabi_contract_options(path = $path)]
+			$(#[ethabi_function_options(signature = $signature, alias = $alias)])*
+			struct _Dummy;
+		}
+    };
+
+    ($module:ident, $path: expr, $($signature:expr => $alias:expr,)*) => {
+        use_contract!(@inner $module, $path, ($($signature => $alias),*));
+    };
+
+	// entry point, start parsing
+    ($module:ident, $path: expr, $($signature:expr => $alias:expr),*) => {
+        use_contract!(@inner $module, $path, ($($signature => $alias),*));
+    };
 }

--- a/derive/src/function.rs
+++ b/derive/src/function.rs
@@ -57,7 +57,13 @@ struct Outputs {
 /// Structure used to generate contract's function interface.
 pub struct Function {
 	/// Function name.
-	name: String,
+	pub name: String,
+	/// Function module name.
+	pub module_name: String,
+	/// Function signature.
+	pub signature: String,
+	/// Function signature.
+	pub short_signature: [u8; 4],
 	/// Function input params.
 	inputs: Inputs,
 	/// Function output params.
@@ -124,8 +130,12 @@ impl<'a> From<&'a ethabi::Function> for Function {
 			}
 		};
 
+
 		Function {
 			name: f.name.clone(),
+			module_name: f.name.clone().to_snake_case(),
+			signature: f.signature().split(":").collect::<Vec<&str>>()[0].to_string(),
+			short_signature: f.short_signature(),
 			inputs: Inputs { tokenize, template_params, recreate_quote: to_ethabi_param_vec(&f.inputs) },
 			outputs: Outputs {
 				implementation: output_implementation,
@@ -141,7 +151,7 @@ impl Function {
 	/// Generates the interface for contract's function.
 	pub fn generate(&self) -> TokenStream {
 		let name = &self.name;
-		let module_name = syn::Ident::new(&self.name.to_snake_case(), Span::call_site());
+		let module_name = syn::Ident::new(&self.module_name, Span::call_site());
 		let tokenize = &self.inputs.tokenize;
 		let declarations: &Vec<_> = &self.inputs.template_params.iter().map(|i| &i.declaration).collect();
 		let definitions: &Vec<_> = &self.inputs.template_params.iter().map(|i| &i.definition).collect();

--- a/derive/src/function.rs
+++ b/derive/src/function.rs
@@ -58,11 +58,11 @@ struct Outputs {
 pub struct Function {
 	/// Function name.
 	pub name: String,
-	/// Function module name.
+	/// Function module name. ex: safe_transfer_from
 	pub module_name: String,
-	/// Function signature.
+	/// Function signature. ex: safeTransferFrom(address,address,uint256)
 	pub signature: String,
-	/// Function signature.
+	/// Function short signature. ex: 0x42842e0e
 	pub short_signature: [u8; 4],
 	/// Function input params.
 	inputs: Inputs,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -39,7 +39,6 @@ fn impl_ethabi_derive(ast: &syn::DeriveInput) -> Result<proc_macro2::TokenStream
 	let source_file = fs::File::open(&normalized_path)
 		.map_err(|_| format!("Cannot load contract abi from `{}`", normalized_path.display()))?;
 	let contract = Contract::load(source_file)?;
-	// let c = contract::Contract::from(&contract);
 	let c = contract::Contract::new(&contract, Some(contract_options));
 	Ok(c.generate())
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,17 +14,19 @@ mod constructor;
 mod contract;
 mod event;
 mod function;
+mod options;
 
 use ethabi::{Contract, Param, ParamType, Result};
 use heck::SnakeCase;
 use quote::quote;
+use options::ContractOptions;
 use std::path::PathBuf;
 use std::{env, fs};
 use syn::export::Span;
 
 const ERROR_MSG: &str = "`derive(EthabiContract)` failed";
 
-#[proc_macro_derive(EthabiContract, attributes(ethabi_contract_options))]
+#[proc_macro_derive(EthabiContract, attributes(ethabi_contract_options,ethabi_function_options))]
 pub fn ethabi_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	let ast = syn::parse(input).expect(ERROR_MSG);
 	let gen = impl_ethabi_derive(&ast).expect(ERROR_MSG);
@@ -32,46 +34,14 @@ pub fn ethabi_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 }
 
 fn impl_ethabi_derive(ast: &syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
-	let options = get_options(&ast.attrs, "ethabi_contract_options")?;
-	let path = get_option(&options, "path")?;
-	let normalized_path = normalize_path(&path)?;
+	let contract_options = ContractOptions::from_attrs(ast.attrs.as_slice())?;
+	let normalized_path = normalize_path(&contract_options.path)?;
 	let source_file = fs::File::open(&normalized_path)
 		.map_err(|_| format!("Cannot load contract abi from `{}`", normalized_path.display()))?;
 	let contract = Contract::load(source_file)?;
-	let c = contract::Contract::from(&contract);
+	// let c = contract::Contract::from(&contract);
+	let c = contract::Contract::new(&contract, Some(contract_options));
 	Ok(c.generate())
-}
-
-fn get_options(attrs: &[syn::Attribute], name: &str) -> Result<Vec<syn::NestedMeta>> {
-	let options = attrs.iter().flat_map(syn::Attribute::parse_meta).find(|meta| meta.path().is_ident(name));
-
-	match options {
-		Some(syn::Meta::List(list)) => Ok(list.nested.into_iter().collect()),
-		_ => Err("Unexpected meta item".into()),
-	}
-}
-
-fn get_option(options: &[syn::NestedMeta], name: &str) -> Result<String> {
-	let item = options
-		.iter()
-		.flat_map(|nested| match *nested {
-			syn::NestedMeta::Meta(ref meta) => Some(meta),
-			_ => None,
-		})
-		.find(|meta| meta.path().is_ident(name))
-		.ok_or_else(|| format!("Expected to find option {}", name))?;
-
-	str_value_of_meta_item(item, name)
-}
-
-fn str_value_of_meta_item(item: &syn::Meta, name: &str) -> Result<String> {
-	if let syn::Meta::NameValue(ref name_value) = *item {
-		if let syn::Lit::Str(ref value) = name_value.lit {
-			return Ok(value.value());
-		}
-	}
-
-	Err(format!(r#"`{}` must be in the form `#[{}="something"]`"#, name, name).into())
 }
 
 fn normalize_path(relative_path: &str) -> Result<PathBuf> {

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -1,0 +1,81 @@
+use syn::Attribute;
+use ethabi::Result;
+use std::collections::HashMap;
+
+pub struct FunctionOptions {
+    pub signature: String,
+    pub alias: String,
+}
+
+pub struct ContractOptions {
+    pub path: String,
+    pub functions: HashMap<String, FunctionOptions>,
+}
+
+impl ContractOptions {
+    pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
+        let options = get_options(attrs, "ethabi_contract_options")?;
+        let path = get_option(&options, "path")?;
+        let functions = get_function_options(attrs)?
+            .into_iter()
+            .fold(HashMap::new(), |mut map, option| {
+                map.entry(option.signature.to_string()).or_insert(option);
+                map
+            });
+        Ok(Self {
+            path,
+            functions,
+        })
+    }
+}
+
+fn get_function_options(attrs: &[syn::Attribute]) -> Result<Vec<FunctionOptions>> {
+    attrs
+        .iter()
+        .flat_map(syn::Attribute::parse_meta)
+        .filter(|meta| meta.path().is_ident("ethabi_function_options"))
+        .filter_map(|meta| -> Option<Vec<syn::NestedMeta>> {
+            match meta {
+                syn::Meta::List(list) => Some(list.nested.into_iter().collect()),
+                _ => None,
+            }
+        })
+        .map(|nested_meta| -> Result<FunctionOptions> {
+            let signature = get_option(&nested_meta, "signature")?;
+            let alias = get_option(&nested_meta, "alias")?;
+            Ok(FunctionOptions { signature, alias })
+        })
+        .collect()
+}
+
+fn get_options(attrs: &[syn::Attribute], name: &str) -> Result<Vec<syn::NestedMeta>> {
+    let options = attrs.iter().flat_map(syn::Attribute::parse_meta).find(|meta| meta.path().is_ident(name));
+
+    match options {
+        Some(syn::Meta::List(list)) => Ok(list.nested.into_iter().collect()),
+        _ => Err("Unexpected meta item".into()),
+    }
+}
+
+fn get_option(options: &[syn::NestedMeta], name: &str) -> Result<String> {
+    let item = options
+        .iter()
+        .flat_map(|nested| match *nested {
+            syn::NestedMeta::Meta(ref meta) => Some(meta),
+            _ => None,
+        })
+        .find(|meta| meta.path().is_ident(name))
+        .ok_or_else(|| format!("Expected to find option {}", name))?;
+
+    str_value_of_meta_item(item, name)
+}
+
+fn str_value_of_meta_item(item: &syn::Meta, name: &str) -> Result<String> {
+    if let syn::Meta::NameValue(ref name_value) = *item {
+        if let syn::Lit::Str(ref value) = name_value.lit {
+            return Ok(value.value());
+        }
+    }
+
+    Err(format!(r#"`{}` must be in the form `#[{}="something"]`"#, name, name).into())
+}

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -79,6 +79,15 @@ impl Function {
 			(_, _) => format!("{}({}):({})", self.name, inputs, outputs),
 		}
 	}
+
+	/// Returns a signature that uniquely identifies this function.
+	///
+	/// Examples:
+	/// - `d7d15059`
+	pub fn short_signature(&self) -> [u8; 4] {
+		let params = self.input_param_types();
+		short_signature(&self.name, &params)
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Issue
Solidity supports method overloading and Rust don’t.

# How to Reproduce
Currently **ethabi-derive** and **ethabi-contract** doesn't support contract with overloaded methods, like the [ERC721](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.2.0/contracts/token/ERC721/IERC721.sol#L54) standard that have two implementations of `safeTransferFrom` method:
```solidity
function safeTransferFrom(address from, address to, uint256 tokenId) external;
function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
```

if we attempt to use
```rust
use_contract!(erc721, "../res/ERC721.abi")
```
Rust will complain with following error:
```
   | use_contract!(erc721, "../res/ERC721.abi");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | `safe_transfer_from` redefined here
   | previous definition of the module `safe_transfer_from` here
   |
   = note: `safe_transfer_from` must be defined only once in the type namespace of this module
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

# Proposal
For `ethabi-derive`, I included a new attribute `ethabi_function_options`, which receives function parameters.
```rust
pub mod erc721 {
    #[derive(ethabi_derive::EthabiContract)]
    #[ethabi_contract_options(path = "../res/ERC721.abi")]
    #[ethabi_function_options(
        signature = "safeTransferFrom(address,address,uint256,bytes)",
        alias = "safe_transfer_from_with_data"
    )]
    struct _Dummy;
}
```

For `ethabi-contract`, I included a new Macro Rule which accepts custom function options.
```rust
use_contract!{
    erc721,
    "../res/ERC721.abi"
    "safeTransferFrom(address,address,uint256,bytes)" => "safe_transfer_from_with_data",
    "safeTransferFrom(address,address,uint256)" => "regular_safe_transfer_from",
};

erc721::functions::safe_transfer_from_with_data::encode_input(...);
erc721::functions::regular_safe_transfer_from::encode_input(...);
```